### PR TITLE
Update to twilight 0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b5ce75405893cd713f9ab8e297d8e438f624dde7d706108285f7e17a25a180f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "179c3777a8b5e70e90ea426114ffc565b2c1a9f82f6c4a0c5a34aa6ef5e781b6"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -308,6 +330,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -336,6 +360,15 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -406,15 +439,6 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "crossbeam-channel"
@@ -668,6 +692,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,17 +795,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "flate2"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
-dependencies = [
- "crc32fast",
- "libz-sys",
- "miniz_oxide",
-]
-
-[[package]]
 name = "floodgate"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +832,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1041,6 +1066,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
 name = "hashlink"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,9 +1265,9 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.7.0",
  "hyper-util",
- "rustls 0.23.31",
+ "rustls 0.23.35",
  "rustls-pki-types",
- "rustls-platform-verifier 0.6.1",
+ "rustls-platform-verifier",
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
@@ -1501,6 +1532,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,17 +1572,6 @@ dependencies = [
  "bitflags 2.9.3",
  "libc",
  "redox_syscall 0.5.17",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -2315,12 +2345,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
- "ring 0.17.14",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2359,27 +2390,6 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls 0.23.31",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework 3.3.0",
- "security-framework-sys",
- "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustls-platform-verifier"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be59af91596cac372a6942530653ad0c3a246cdd491aaa9dcaee47f88d67d5a0"
@@ -2389,13 +2399,13 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.31",
+ "rustls 0.23.35",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
  "security-framework 3.3.0",
  "security-framework-sys",
- "webpki-root-certs 1.0.2",
+ "webpki-root-certs",
  "windows-sys 0.59.0",
 ]
 
@@ -2407,10 +2417,11 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
+ "aws-lc-rs",
  "ring 0.17.14",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -3027,6 +3038,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rust-fuzzy-search",
+ "rustls 0.23.35",
  "sentry",
  "serde",
  "serde_json",
@@ -3303,7 +3315,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.31",
+ "rustls 0.23.35",
  "tokio",
 ]
 
@@ -3328,14 +3340,15 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
+ "slab",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-websockets"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fcaf159b4e7a376b05b5bfd77bfd38f3324f5fce751b4213bfc7eaa47affb4e"
+checksum = "19d469594aed8da8afbb9dfd33a5548f057f74d6c8e3a50b142b04398f91029a"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3344,9 +3357,8 @@ dependencies = [
  "futures-sink",
  "http 1.3.1",
  "httparse",
- "ring 0.17.14",
  "rustls-pki-types",
- "rustls-platform-verifier 0.5.3",
+ "rustls-platform-verifier",
  "sha1_smol",
  "simdutf8",
  "tokio",
@@ -3435,13 +3447,12 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twilight-gateway"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "863ef55467bcf6a2958162766fd0b72f33112e36971b37f9ec09b86d4fd0f7d1"
+checksum = "6ade57432c8ba31126ce40af996622864ccde1b95c95d538414d4c23191f4171"
 dependencies = [
  "bitflags 2.9.3",
  "fastrand 2.3.0",
- "flate2",
  "futures-core",
  "futures-sink",
  "serde",
@@ -3452,13 +3463,14 @@ dependencies = [
  "twilight-gateway-queue",
  "twilight-http",
  "twilight-model",
+ "zstd-safe",
 ]
 
 [[package]]
 name = "twilight-gateway-queue"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c962bd4693da0a215abe6b431fd73eb87111f49c431b87951780f9f7985002"
+checksum = "366a73fe47f61a3d522c3aaf70475e60634b0ae59e7b94272ed7496fffa7ceb7"
 dependencies = [
  "tokio",
  "tracing",
@@ -3466,9 +3478,9 @@ dependencies = [
 
 [[package]]
 name = "twilight-http"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9a2176638fd8bfeb867e7a2f644fee0db905eba6f7decfdcd75c8171109b74"
+checksum = "cb36574ad2d30e1dbb39876265c66d37ee60969ffdcc1f0ebb9ace2ca42d74ff"
 dependencies = [
  "brotli-decompressor",
  "fastrand 2.3.0",
@@ -3478,7 +3490,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "percent-encoding",
- "rustls 0.23.31",
+ "rustls 0.23.35",
  "serde",
  "serde_json",
  "tokio",
@@ -3490,19 +3502,20 @@ dependencies = [
 
 [[package]]
 name = "twilight-http-ratelimiting"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a36945d949920d6bb6aef30547e06ea645eefaa5575a14f56da608bf09d07ec8"
+checksum = "f3c0fa6e3578e0f6dc4636eed55e3c0dd51b5898de2b7200f7fec025656c1148"
 dependencies = [
+ "hashbrown 0.16.1",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "twilight-interactions"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04837fa6d36de8c1446dd314095bcdc59a7c8021bf0dbf1dd0a846f1c146244"
+version = "0.17.0"
+source = "git+https://github.com/ghostlylake/twilight-interactions?branch=twilight-0.17#c7808feeb0c84e7fd61bc6211f2433cdba270e26"
 dependencies = [
  "twilight-interactions-derive",
  "twilight-model",
@@ -3510,9 +3523,8 @@ dependencies = [
 
 [[package]]
 name = "twilight-interactions-derive"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d42db71d6bffdca42068bbbe12d1201065ca9d3fb718ec7f28dc4c680977da2"
+version = "0.17.0"
+source = "git+https://github.com/ghostlylake/twilight-interactions?branch=twilight-0.17#c7808feeb0c84e7fd61bc6211f2433cdba270e26"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3521,18 +3533,18 @@ dependencies = [
 
 [[package]]
 name = "twilight-mention"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e637a25046dcd3bb2926916161ca9a44dbe1966de3f1e20494fac612ccf1759"
+checksum = "b4aebfdf7f045520f52ad09d2c2cd50f138afccccbf92a2647d463d7d04e10b0"
 dependencies = [
  "twilight-model",
 ]
 
 [[package]]
 name = "twilight-model"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191e2efa051dfbd9bed4c9f6bd3f5e007bda909c687a1db2760371a3d566617d"
+checksum = "416247a86048c1909954c95c64ca4c7fbbcb44c36e9cbed8c008e7e40988f610"
 dependencies = [
  "bitflags 2.9.3",
  "serde",
@@ -3543,9 +3555,9 @@ dependencies = [
 
 [[package]]
 name = "twilight-standby"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375267fde44a8d52a8bf01c60d0769d9d2a289d056f278da4e99186ae04c5903"
+checksum = "f3c152f9911c2ddc9975c3919a4570e9c841a18193af74f5c8d55ad3bd7b577a"
 dependencies = [
  "dashmap 6.1.0",
  "futures-core",
@@ -3556,9 +3568,9 @@ dependencies = [
 
 [[package]]
 name = "twilight-util"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5777d71286611c1639021f5f6e6b40300eb8da278449ac1cf6da01c94053425"
+checksum = "e71de79d48ce27aba1f591b10c84677f1317489c2ea154d9b8ed01efa8bceb53"
 dependencies = [
  "twilight-model",
  "twilight-validate",
@@ -3566,9 +3578,9 @@ dependencies = [
 
 [[package]]
 name = "twilight-validate"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f8d106028ede53708526364b03318bbf846babe146e3ff9e39821a0ca25ff4"
+checksum = "d6a27472e023e3841d1c4e4e20253ed796e8440aada8b5205b8544f1172e661d"
 dependencies = [
  "twilight-model",
 ]
@@ -3847,15 +3859,6 @@ checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
  "ring 0.17.14",
  "untrusted 0.9.0",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
-dependencies = [
- "webpki-root-certs 1.0.2",
 ]
 
 [[package]]
@@ -4389,4 +4392,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,15 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-twilight-gateway = "0.16.0"
-twilight-http = "0.16.0"
-twilight-model = "0.16.0"
-twilight-validate = "0.16.0"
-twilight-util = { version = "0.16.0", features = ["builder", "snowflake"] }
-twilight-mention = "0.16.0"
-twilight-standby = "0.16.0"
+twilight-gateway = "0.17.0"
+twilight-http = "0.17.0"
+twilight-model = "0.17.0"
+twilight-validate = "0.17.0"
+twilight-util = { version = "0.17.0", features = ["builder", "snowflake"] }
+twilight-mention = "0.17.0"
+twilight-standby = "0.17.0"
 
-twilight-interactions = "0.16.2"
+twilight-interactions = { version = "0.17.0", git = "https://github.com/ghostlylake/twilight-interactions", branch = "twilight-0.17"}
 
 async-trait = "0.1.89"
 tokio = { version = "1.47.1", features = ["full"] }
@@ -41,3 +41,4 @@ moka = { version = "0.11.3", features = ["future"] }
 cached = "0.44.0"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
+rustls = { version = "0.23.35" }

--- a/src/core/embedder/builder.rs
+++ b/src/core/embedder/builder.rs
@@ -97,6 +97,7 @@ impl BuiltStarboardEmbed {
                 handle.orig_sql_message.channel_id,
                 handle.orig_sql_message.message_id,
             )),
+            id: None,
         })
     }
 
@@ -107,6 +108,7 @@ impl BuiltStarboardEmbed {
 
         vec![Component::ActionRow(ActionRow {
             components: vec![Component::Button(gtm)],
+            id: None,
         })]
     }
 

--- a/src/interactions/commands/chat/help.rs
+++ b/src/interactions/commands/chat/help.rs
@@ -20,6 +20,7 @@ fn buttons() -> Vec<Component> {
             label: Some(name.into()),
             style: ButtonStyle::Link,
             url: Some(link.into()),
+            id: None,
         })
     };
 
@@ -33,6 +34,7 @@ fn buttons() -> Vec<Component> {
 
     let row = Component::ActionRow(ActionRow {
         components: buttons,
+        id: None,
     });
 
     vec![row]

--- a/src/interactions/commands/chat/moststarred.rs
+++ b/src/interactions/commands/chat/moststarred.rs
@@ -123,6 +123,7 @@ fn components(
             label: Some("Back".to_string()),
             style: ButtonStyle::Secondary,
             url: None,
+            id: None,
         }),
         Component::Button(Button {
             sku_id: None,
@@ -132,6 +133,7 @@ fn components(
             label: Some(current_page.to_string()),
             style: ButtonStyle::Secondary,
             url: None,
+            id: None,
         }),
         Component::Button(Button {
             sku_id: None,
@@ -141,16 +143,19 @@ fn components(
             label: Some("Next".to_string()),
             style: ButtonStyle::Secondary,
             url: None,
+            id: None,
         }),
     ];
 
     let mut action_rows = vec![Component::ActionRow(ActionRow {
         components: buttons,
+        id: None,
     })];
 
     if let Some(btn) = gtm_btn {
         action_rows.push(Component::ActionRow(ActionRow {
             components: vec![Component::Button(btn)],
+            id: None,
         }));
     }
 

--- a/src/utils/notify.rs
+++ b/src/utils/notify.rs
@@ -27,7 +27,9 @@ pub async fn notify(
             custom_id: Some("stateless::dismiss_notification".to_string()),
             disabled: false,
             emoji: None,
+            id: None,
         })],
+        id: None,
     });
 
     let _ = dm::dm(bot, user_id)

--- a/src/utils/views/confirm.rs
+++ b/src/utils/views/confirm.rs
@@ -29,6 +29,7 @@ pub fn components(danger: bool) -> Vec<Component> {
             label: Some("Cancel".to_string()),
             style: ButtonStyle::Secondary,
             url: None,
+            id: None,
         }),
         Component::Button(Button {
             sku_id: None,
@@ -42,11 +43,13 @@ pub fn components(danger: bool) -> Vec<Component> {
                 ButtonStyle::Primary
             },
             url: None,
+            id: None,
         }),
     ];
 
     let row = Component::ActionRow(ActionRow {
         components: buttons,
+        id: None,
     });
 
     vec![row]

--- a/src/utils/views/paginator.rs
+++ b/src/utils/views/paginator.rs
@@ -26,6 +26,7 @@ pub fn components(current_page: usize, last_page: usize, done: bool) -> Vec<Comp
             label: Some("<<".to_string()),
             style: ButtonStyle::Secondary,
             url: None,
+            id: None,
         }),
         Component::Button(Button {
             sku_id: None,
@@ -35,6 +36,7 @@ pub fn components(current_page: usize, last_page: usize, done: bool) -> Vec<Comp
             label: Some("<".to_string()),
             style: ButtonStyle::Secondary,
             url: None,
+            id: None,
         }),
         Component::Button(Button {
             sku_id: None,
@@ -44,6 +46,7 @@ pub fn components(current_page: usize, last_page: usize, done: bool) -> Vec<Comp
             label: Some(format!("{}/{}", current_page + 1, last_page + 1)),
             style: ButtonStyle::Secondary,
             url: None,
+            id: None,
         }),
         Component::Button(Button {
             sku_id: None,
@@ -53,6 +56,7 @@ pub fn components(current_page: usize, last_page: usize, done: bool) -> Vec<Comp
             label: Some(">".to_string()),
             style: ButtonStyle::Secondary,
             url: None,
+            id: None,
         }),
         Component::Button(Button {
             sku_id: None,
@@ -62,11 +66,13 @@ pub fn components(current_page: usize, last_page: usize, done: bool) -> Vec<Comp
             label: Some(">>".to_string()),
             style: ButtonStyle::Secondary,
             url: None,
+            id: None,
         }),
     ];
 
     let row = Component::ActionRow(ActionRow {
         components: buttons,
+        id: None,
     });
 
     vec![row]

--- a/src/utils/views/select_paginator.rs
+++ b/src/utils/views/select_paginator.rs
@@ -197,6 +197,7 @@ impl SelectPaginator {
                 label: Some("<".to_string()),
                 style: ButtonStyle::Secondary,
                 url: None,
+                id: None,
             }),
             Component::Button(Button {
                 sku_id: None,
@@ -206,6 +207,7 @@ impl SelectPaginator {
                 label: Some(format!("{}/{}", current + 1, last_chunk + 1)),
                 style: ButtonStyle::Secondary,
                 url: None,
+                id: None,
             }),
             Component::Button(Button {
                 sku_id: None,
@@ -215,6 +217,7 @@ impl SelectPaginator {
                 label: Some(">".to_string()),
                 style: ButtonStyle::Secondary,
                 url: None,
+                id: None,
             }),
         ];
 
@@ -245,6 +248,8 @@ impl SelectPaginator {
             min_values: Some(1),
             options: Some(options),
             placeholder: None,
+            id: None,
+            required: None,
         })
     }
 
@@ -254,11 +259,13 @@ impl SelectPaginator {
         if let Some(buttons) = self.pagination_buttons() {
             rows.push(Component::ActionRow(ActionRow {
                 components: buttons,
+                id: None,
             }));
         }
 
         rows.push(Component::ActionRow(ActionRow {
             components: vec![self.select_component()],
+            id: None,
         }));
 
         rows


### PR DESCRIPTION
Will push a commit to switch back to the `twilight-interactions` crates.io crate when support for 0.17 is merged into it (unless you'd rather merge this beforehand)