### PR TITLE
Remove GUILD_MEMBERS intent

### DIFF
--- a/src/client/bot.rs
+++ b/src/client/bot.rs
@@ -47,7 +47,6 @@ impl StarboardBot {
         // Setup gateway connection
         let intents = Intents::GUILDS
             | Intents::GUILD_EMOJIS_AND_STICKERS
-            | Intents::GUILD_MEMBERS
             | Intents::GUILD_MESSAGES
             | Intents::DIRECT_MESSAGES
             | Intents::MESSAGE_CONTENT


### PR DESCRIPTION
This is a [privileged intent](https://docs.discord.com/developers/events/gateway#privileged-intents) which invites extra scrutiny from Discord when operating the bot on large guilds.

I examined the codebase and there's not any code to handle any gateway events under the GUILD_MEMBERS family anyways, so this appears to be unneeded.

Tested by running it on a large community Discord guild of 14k members for a few days.

Ideally we can remove the other privileged intents too, but MESSAGE_CONTENT is actually used by parts of the code, so left it in for now.